### PR TITLE
Deprecate install-hook in favor of pre-commit framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,19 @@ docsync validate-links
 docsync coverage
 
 # Enable pre-commit enforcement
-docsync install-hook
+pip install pre-commit
+
+# Add to .pre-commit-config.yaml:
+- repo: local
+  hooks:
+    - id: docsync-check
+      name: docsync-check
+      entry: uv run docsync check
+      language: system
+      pass_filenames: false
+
+# Install hooks
+pre-commit install
 
 # Now commits block if docs are stale
 git commit -m "refactor auth"

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -30,18 +30,30 @@ docsync init
 
 ### install-hook
 
-Install the pre-commit hook.
+⚠️ **Deprecated** - Use the pre-commit framework instead.
 
 ```bash
+# Don't use this - it's deprecated
 docsync install-hook
 ```
 
-**Effect:**
+**Modern approach:**
 
-- Creates `.git/hooks/pre-commit` script
-- Hook runs `docsync check` before each commit
+Add to `.pre-commit-config.yaml`:
 
-**When to use:** After `docsync init` to enable enforcement.
+```yaml
+- repo: local
+  hooks:
+    - id: docsync-check
+      name: docsync-check
+      entry: uv run docsync check
+      language: system
+      pass_filenames: false
+```
+
+Then install: `pre-commit install`
+
+**Why deprecated:** Direct `.git/hooks/` scripts conflict with tool managers (uv, pipx, pyenv). The pre-commit framework is the standard approach for Python tools.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -110,7 +110,6 @@ Validation catches typos and missing sections. Coverage shows what percentage of
 ```bash
 docsync check           # Pre-commit: validate links + check staged files for stale docs
 docsync list-stale      # Audit: list ALL stale docs across entire repo
-docsync install-hook    # Add pre-commit hook to .pre-commit-config.yaml
 ```
 
 The `check` command runs during pre-commit and performs two validations:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -23,7 +23,19 @@ docsync validate-links
 docsync coverage
 
 # Enable pre-commit enforcement
-docsync install-hook
+pip install pre-commit  # or: uv tool install pre-commit
+
+# Add to .pre-commit-config.yaml:
+- repo: local
+  hooks:
+    - id: docsync-check
+      name: docsync-check
+      entry: uv run docsync check
+      language: system
+      pass_filenames: false
+
+# Install hooks
+pre-commit install
 
 # Now commits block if docs are stale:
 git commit -m "refactor auth"

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,7 +68,19 @@ docsync validate-links
 docsync coverage
 
 # Enable pre-commit enforcement
-docsync install-hook
+pip install pre-commit
+
+# Add to .pre-commit-config.yaml:
+- repo: local
+  hooks:
+    - id: docsync-check
+      name: docsync-check
+      entry: uv run docsync check
+      language: system
+      pass_filenames: false
+
+# Install hooks
+pre-commit install
 
 # Now commits block if docs are stale
 git commit -m "refactor auth"

--- a/src/docsync/cli.py
+++ b/src/docsync/cli.py
@@ -797,33 +797,32 @@ def cmd_clear_cache(args: argparse.Namespace) -> int:
 
 
 def cmd_install_hook(args: argparse.Namespace) -> int:
-    """Install pre-commit hook."""
-    repo_root = Path.cwd()
-    hooks_dir = repo_root / ".git" / "hooks"
-
-    if not hooks_dir.exists():
-        print("⚠️  Not in a git repository")
-        return 1
-
-    hook_path = hooks_dir / "pre-commit"
-    hook_content = """#!/bin/bash
-# docsync pre-commit hook
-
-docsync check
-exit $?
-"""
-
-    if hook_path.exists():
-        print("⚠️  pre-commit hook already exists")
-        print(f"Add this line to {hook_path}:")
-        print("  docsync check")
-        return 1
-
-    hook_path.write_text(hook_content)
-    hook_path.chmod(0o755)
-    print(f"✓ Installed pre-commit hook at {hook_path}")
-
-    return 0
+    """Install pre-commit hook (deprecated - use pre-commit framework instead)."""
+    print("⚠️  This command is deprecated.")
+    print()
+    print("Modern Python projects use the pre-commit framework instead of direct git hooks.")
+    print("This avoids conflicts with tool managers (uv, pipx, pyenv).")
+    print()
+    print("Recommended setup:")
+    print()
+    print("1. Install pre-commit:")
+    print("   pip install pre-commit")
+    print()
+    print("2. Add to .pre-commit-config.yaml:")
+    print()
+    print("   - repo: local")
+    print("     hooks:")
+    print("       - id: docsync-check")
+    print("         name: docsync-check")
+    print("         entry: uv run docsync check  # or: pipx run docsync check")
+    print("         language: system")
+    print("         pass_filenames: false")
+    print()
+    print("3. Install hooks:")
+    print("   pre-commit install")
+    print()
+    print("See: https://pre-commit.com/")
+    return 1
 
 
 def cmd_check_protected(args: argparse.Namespace) -> int:

--- a/tests/test_cli_simple.py
+++ b/tests/test_cli_simple.py
@@ -112,19 +112,16 @@ def test_cmd_coverage_basic(tmp_path, monkeypatch):
 
 
 def test_cmd_install_hook_creates_hook(tmp_path, monkeypatch):
-    """Test install_hook creates git hook."""
+    """Test install_hook prints deprecation warning."""
     monkeypatch.chdir(tmp_path)
 
     # Initialize git repo
-
     subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True)
 
     result = cmd_install_hook(Namespace())
 
-    assert result == 0
-    hook_file = tmp_path / ".git" / "hooks" / "pre-commit"
-    assert hook_file.exists()
-    assert "docsync" in hook_file.read_text()
+    # Command now returns 1 (deprecated)
+    assert result == 1
 
 
 def test_cmd_check_no_config(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

This PR deprecates the `docsync install-hook` command in favor of the pre-commit framework, which is the modern standard for Python tools.

## Problem (Issue #10)

When `docsync` is installed via `uv tool install` or `pipx`, the `install-hook` command creates direct git hooks that rely on PATH resolution. This conflicts with pyenv shims, causing:

```bash
$ docsync --help
ModuleNotFoundError: No module named 'docsync'
```

## Solution

Use the pre-commit framework instead, which:
- Avoids PATH conflicts with `language: system` and explicit `uv run` prefix
- Is the standard approach for modern Python tools (ruff, black, mypy, etc.)
- Is how docsync itself already works (see `.pre-commit-config.yaml`)

## Changes

**Documentation:**
- Updated all docs (README, index, getting-started, configuration, CLI reference) to show pre-commit framework setup
- Removed references to `docsync install-hook` from quick start guides

**Code:**
- Modified `install-hook` command to print deprecation warning with migration instructions
- Command now returns exit code 1 to signal it shouldn't be used
- Updated test to expect deprecation behavior (returns 1 instead of 0)

**Migration path for users:**

Add to `.pre-commit-config.yaml`:
```yaml
- repo: local
  hooks:
    - id: docsync-check
      name: docsync-check
      entry: uv run docsync check
      language: system
      pass_filenames: false
```

Then run: `pre-commit install`

## Closes

Closes #10