### PR TITLE
feat: integrate Codecov with coverage thresholds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,10 @@ jobs:
         run: uv run menard check
 
       - name: Run tests with coverage
-        run: uv run pytest --cov=src/menard --cov-report=term --cov-report=xml --cov-fail-under=60
+        run: uv run pytest --cov=src/menard --cov-branch --cov-report=term --cov-report=xml --cov-fail-under=65
 
       - name: Upload coverage to Codecov
+        if: matrix.python-version == '3.12'
         uses: codecov/codecov-action@v5
         with:
           file: ./coverage.xml

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 <p align="center">
   <a href="https://github.com/nlebovits/menard/actions/workflows/ci.yml"><img src="https://github.com/nlebovits/menard/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://codecov.io/gh/nlebovits/menard"><img src="https://codecov.io/gh/nlebovits/menard/branch/main/graph/badge.svg" alt="codecov"></a>
   <a href="https://pypi.org/project/menard/"><img src="https://img.shields.io/pypi/v/menard" alt="PyPI"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10+-blue.svg" alt="Python 3.10+"></a>
   <a href="https://github.com/nlebovits/menard/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License"></a>

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,18 @@
+# Codecov configuration
+# https://docs.codecov.com/docs/codecov-yaml
+
+coverage:
+  status:
+    project:
+      default:
+        target: 65%
+        threshold: 0%
+    patch:
+      default:
+        target: 55%
+        threshold: 10%
+
+comment:
+  layout: "header, diff, flags, files"
+  behavior: default
+  require_changes: true


### PR DESCRIPTION
## Summary
- Add `codecov.yml` with 65% project target and 55% patch target (10% tolerance)
- Enable branch coverage tracking (`--cov-branch`)
- Raise CI coverage threshold from 60% to 65%
- Upload coverage only from Python 3.12 to avoid duplicate reports
- Add Codecov badge to README

## Test plan
- [ ] CI passes with coverage threshold
- [ ] Codecov receives coverage report after merge
- [ ] Badge displays correctly in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)